### PR TITLE
Add automatic fixed lint git hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
       },
     ],
     // formatting
-    // pay attention not to make conflict with prettier
+    // pay attention to use same rules with prettier
     quotes: ['error', 'single'],
     'jsx-quotes': ['error', 'prefer-single'],
     indent: ['error', 2],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   root: true,
-  ignorePatterns: ['**/*'],
+  ignorePatterns: ['apps/**/*'],
   plugins: ['@nrwl/nx'],
   extends: [
     'airbnb',
@@ -23,7 +23,16 @@ module.exports = {
         ],
       },
     ],
-    // less stric
+    // formatting
+    // pay attention not to make conflict with prettier
+    quotes: ['error', 'single'],
+    'jsx-quotes': ['error', 'prefer-single'],
+    indent: ['error', 2],
+    'no-multi-spaces': 'error',
+    'no-trailing-spaces': 'error',
+    'array-bracket-spacing': ['error', 'never'],
+    'object-curly-spacing': ['error', 'always'],
+    // less strict
     '@typescript-eslint/no-empty-interface': 'off',
     // import
     'import/order': [

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+yarn tsc
 npx lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,8 @@
 
 /dist
 /coverage
+
+*.js
+*.jsx
+*.ts
+*.tsx

--- a/apps/zoopi-web/.storybook/preview.jsx
+++ b/apps/zoopi-web/.storybook/preview.jsx
@@ -16,7 +16,7 @@ export const decorators = [
     <ThemeProvider>
       <GlobalStyle />
       <Story />
-      <div id="root-modal" />
+      <div id='root-modal' />
     </ThemeProvider>
   ),
 ];

--- a/apps/zoopi-web/components/AnimalChip/AnimalChip.tsx
+++ b/apps/zoopi-web/components/AnimalChip/AnimalChip.tsx
@@ -50,8 +50,8 @@ export const AnimalChip = ({
   );
 
   return (
-    <button type="button" onClick={onClick} css={css} {...rest}>
-      {image && <Image width={48} height={48} alt="animal-image" src={image} />}
+    <button type='button' onClick={onClick} css={css} {...rest}>
+      {image && <Image width={48} height={48} alt='animal-image' src={image} />}
       {!image && (
         <div
           css={{

--- a/apps/zoopi-web/components/Button/Button.test.tsx
+++ b/apps/zoopi-web/components/Button/Button.test.tsx
@@ -13,7 +13,7 @@ test('trigger onClick', () => {
   expect(handleClick).toBeCalledTimes(1);
 });
 
-test("don't trigger onClick when it's disabled", () => {
+test('don\'t trigger onClick when it\'s disabled', () => {
   const handleClick = jest.fn();
   const BUTTON_TEXT = 'BUTTON';
 

--- a/apps/zoopi-web/components/Logo/Logo.tsx
+++ b/apps/zoopi-web/components/Logo/Logo.tsx
@@ -19,7 +19,7 @@ export const Logo = ({ height, width }: LogoProps) => {
     >
       <ReactSVG
         css={{ display: 'inline-block' }}
-        src="/zoopi-logo.svg"
+        src='/zoopi-logo.svg'
         beforeInjection={(svg) => {
           svg.setAttribute('style', `width: ${width}px; height: ${height}px;`);
         }}

--- a/apps/zoopi-web/components/Modal/Modal.tsx
+++ b/apps/zoopi-web/components/Modal/Modal.tsx
@@ -39,49 +39,49 @@ export const Modal = ({ onClose, height, width, children }: ModalProps) => {
 
   return isMount
     ? createPortal(
-        // TODO: uncomment and fix eslint errors
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-        <div
-          onClick={handleOverlayClick}
+      // TODO: uncomment and fix eslint errors
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+      <div
+        onClick={handleOverlayClick}
+        css={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          backgroundColor: 'rgba(0,0,0,0.6)',
+        }}
+      >
+        <section
+          ref={modalInsideRef}
+          role='dialog'
+          aria-labelledby='dialogTitle'
+          aria-describedby='dialogDesc'
+          aria-live='polite'
+          aria-atomic='true'
+          aria-modal='true'
           css={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-            backgroundColor: 'rgba(0,0,0,0.6)',
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'stretch',
+            justifyContent: 'space-between',
+            backgroundColor: theme.colors.white,
+            width: width || 'fit-content',
+            height: height || 'fit-content',
+            minWidth: 386,
+            minHeight: 200,
+            borderRadius: '12px',
+            padding: 20,
           }}
         >
-          <section
-            ref={modalInsideRef}
-            role="dialog"
-            aria-labelledby="dialogTitle"
-            aria-describedby="dialogDesc"
-            aria-live="polite"
-            aria-atomic="true"
-            aria-modal="true"
-            css={{
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'stretch',
-              justifyContent: 'space-between',
-              backgroundColor: theme.colors.white,
-              width: width || 'fit-content',
-              height: height || 'fit-content',
-              minWidth: 386,
-              minHeight: 200,
-              borderRadius: '12px',
-              padding: 20,
-            }}
-          >
-            {children}
-          </section>
-        </div>,
+          {children}
+        </section>
+      </div>,
         document.querySelector('#root-modal') as Element
-      )
+    )
     : null;
 };

--- a/apps/zoopi-web/components/ModalConfirm/ModalConfirm.stories.tsx
+++ b/apps/zoopi-web/components/ModalConfirm/ModalConfirm.stories.tsx
@@ -24,7 +24,7 @@ const Template: ComponentStory<typeof ModalConfirm> = (args) => {
 
   return (
     <>
-      <button type="button" onClick={() => setIsModalShow(true)}>
+      <button type='button' onClick={() => setIsModalShow(true)}>
         Open Modal
       </button>
       {isModalShow && (

--- a/apps/zoopi-web/components/ModalConfirm/ModalConfirm.tsx
+++ b/apps/zoopi-web/components/ModalConfirm/ModalConfirm.tsx
@@ -26,7 +26,7 @@ export const ModalConfirm = ({
   <Modal onClose={onClose}>
     <header css={{ display: 'flex', alignItems: 'baseline' }}>
       <h1
-        id="dialogTitle"
+        id='dialogTitle'
         css={{
           flexBasis: '100%',
           flexWrap: 'wrap',
@@ -39,8 +39,8 @@ export const ModalConfirm = ({
       >
         {title}
       </h1>
-      <button type="button" onClick={onClose}>
-        <Icon name="close" size={24} />
+      <button type='button' onClick={onClose}>
+        <Icon name='close' size={24} />
       </button>
     </header>
     <main
@@ -49,7 +49,7 @@ export const ModalConfirm = ({
       }}
     >
       <p
-        id="dialogDesc"
+        id='dialogDesc'
         css={{
           whiteSpace: 'pre-line',
           fontSize: 16,
@@ -73,8 +73,8 @@ export const ModalConfirm = ({
       {cancel && (
         <div>
           <Button
-            color="gray"
-            appearance="outline"
+            color='gray'
+            appearance='outline'
             onClick={cancel.onCancelClick}
           >
             {cancel.cancelMessage || '취소'}
@@ -83,7 +83,7 @@ export const ModalConfirm = ({
       )}
       {confirm && (
         <div>
-          <Button color="main" onClick={confirm.onConfirmClick}>
+          <Button color='main' onClick={confirm.onConfirmClick}>
             {confirm.confirmMessage || '확인'}
           </Button>
         </div>

--- a/apps/zoopi-web/components/ModalLogin/ModalLogin.stories.tsx
+++ b/apps/zoopi-web/components/ModalLogin/ModalLogin.stories.tsx
@@ -13,7 +13,7 @@ const Template: ComponentStory<typeof ModalLogin> = (args) => {
 
   return (
     <>
-      <button type="button" onClick={() => setIsModalShow(true)}>
+      <button type='button' onClick={() => setIsModalShow(true)}>
         Open Modal
       </button>
       {isModalShow && (

--- a/apps/zoopi-web/components/ModalLogin/ModalLogin.tsx
+++ b/apps/zoopi-web/components/ModalLogin/ModalLogin.tsx
@@ -63,7 +63,7 @@ export const ModalLogin = ({ onClose }: ModalLoginProps) => {
   );
 
   return (
-    <Modal onClose={onClose} height="600px" width="560px">
+    <Modal onClose={onClose} height='600px' width='560px'>
       <div
         css={{
           padding: '0 80px',
@@ -71,10 +71,10 @@ export const ModalLogin = ({ onClose }: ModalLoginProps) => {
           justifyContent: 'center',
           height: '100%',
         }}
-        aria-label="loginForm"
+        aria-label='loginForm'
       >
         <button
-          type="button"
+          type='button'
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus // TODO: fix eslint error
           onClick={onClose}
@@ -86,11 +86,11 @@ export const ModalLogin = ({ onClose }: ModalLoginProps) => {
             marginLeft: 10,
           }}
         >
-          <Icon name="close" size={24} />
+          <Icon name='close' size={24} />
         </button>
         <div
           css={{ justifyContent: 'center', marginBottom: 50 }}
-          aria-label="zoopi logo"
+          aria-label='zoopi logo'
         >
           <Logo height={59} width={157} />
         </div>
@@ -110,12 +110,12 @@ export const ModalLogin = ({ onClose }: ModalLoginProps) => {
           <div css={{ marginBottom: 32 }}>
             <PasswordField ref={passwordRef} />
           </div>
-          <Button color="main" appearance="filled" css={{ fontWeight: 700 }}>
+          <Button color='main' appearance='filled' css={{ fontWeight: 700 }}>
             로그인
           </Button>
         </form>
         <div css={{ flexDirection: 'column', position: 'relative' }}>
-          <Button appearance="outline" css={{ marginBottom: 16 }}>
+          <Button appearance='outline' css={{ marginBottom: 16 }}>
             <span
               css={{
                 position: 'absolute',
@@ -124,12 +124,12 @@ export const ModalLogin = ({ onClose }: ModalLoginProps) => {
                 color: theme.colors['grey-70'],
               }}
             >
-              <Icon name="naver" size={24} />
+              <Icon name='naver' size={24} />
             </span>
             네이버로 시작하기
           </Button>
           <div css={{ marginTop: 16, alignItems: 'center' }}>
-            <Link href="/signup" passHref>
+            <Link href='/signup' passHref>
               {/* TODO: fix eslint error */}
               {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
               <a
@@ -150,7 +150,7 @@ export const ModalLogin = ({ onClose }: ModalLoginProps) => {
                 color: theme.colors['grey-50'],
               }}
             />
-            <Link href="/find/id" passHref>
+            <Link href='/find/id' passHref>
               {/* TODO: fix eslint error */}
               {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
               <a
@@ -171,7 +171,7 @@ export const ModalLogin = ({ onClose }: ModalLoginProps) => {
                 color: theme.colors['grey-50'],
               }}
             />
-            <Link href="/find/password" passHref>
+            <Link href='/find/password' passHref>
               {/* TODO: fix eslint error */}
               {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
               <a

--- a/apps/zoopi-web/components/SearchBar/SearchBar.tsx
+++ b/apps/zoopi-web/components/SearchBar/SearchBar.tsx
@@ -81,13 +81,13 @@ export const SearchBar = ({
         {right}
         {clearDisabled ? null : (
           <button
-            type="button"
+            type='button'
             onClick={handleClearClick}
             css={{
               display: 'inline-flex',
             }}
           >
-            <Icon name="search" color={theme.colors['grey-50']} size={24} />
+            <Icon name='search' color={theme.colors['grey-50']} size={24} />
           </button>
         )}
       </div>
@@ -95,7 +95,7 @@ export const SearchBar = ({
         {right}
         {clearDisabled ? null : (
           <button
-            type="button"
+            type='button'
             onClick={handleClearClick}
             css={{
               display: value || localValue ? 'inline-flex' : 'none',
@@ -104,7 +104,7 @@ export const SearchBar = ({
               paddingLeft: 2,
             }}
           >
-            <Icon name="close-circle" color={theme.colors['grey-50']} />
+            <Icon name='close-circle' color={theme.colors['grey-50']} />
           </button>
         )}
       </div>

--- a/apps/zoopi-web/components/Select/Select.tsx
+++ b/apps/zoopi-web/components/Select/Select.tsx
@@ -35,7 +35,7 @@ export const Select = ({
       css={{ border: 0, color: '#393939', fontSize: 13, paddingRight: 4 }}
     >
       {children}
-      <option value="">{name}</option>
+      <option value=''>{name}</option>
     </select>
   </div>
 );

--- a/apps/zoopi-web/components/TextInput/TextInput.tsx
+++ b/apps/zoopi-web/components/TextInput/TextInput.tsx
@@ -127,7 +127,7 @@ export const TextInput = ({
         {right}
         {clearDisabled ? null : (
           <button
-            type="button"
+            type='button'
             onClick={handleClearClick}
             css={{
               display: value || localValue ? 'inline-flex' : 'none',
@@ -136,7 +136,7 @@ export const TextInput = ({
               paddingLeft: 2,
             }}
           >
-            <Icon name="close-circle" color={theme.colors['grey-50']} />
+            <Icon name='close-circle' color={theme.colors['grey-50']} />
           </button>
         )}
       </div>

--- a/apps/zoopi-web/components/TextInputPassword/TextInputPassword.tsx
+++ b/apps/zoopi-web/components/TextInputPassword/TextInputPassword.tsx
@@ -23,11 +23,11 @@ export const TextInputPassword = ({ ...rest }: TextInputPasswordProps) => {
       type={type}
       right={
         <button
-          type="button"
+          type='button'
           css={{ paddingRight: 2, paddingLeft: 2, cursor: 'pointer' }}
           onClick={handleEyeClick}
         >
-          <Icon name="eye" color={theme.colors['grey-60']} />
+          <Icon name='eye' color={theme.colors['grey-60']} />
         </button>
       }
       {...rest}

--- a/apps/zoopi-web/pages/_document.page.tsx
+++ b/apps/zoopi-web/pages/_document.page.tsx
@@ -19,14 +19,14 @@ export default class MyDocument extends Document {
       <Html>
         <Head />
         <link
-          href="//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css"
-          rel="preload"
-          as="style"
+          href='//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css'
+          rel='preload'
+          as='style'
         />
         <body>
           <Main />
           <NextScript />
-          <div id="root-modal" />
+          <div id='root-modal' />
         </body>
       </Html>
     );

--- a/apps/zoopi-web/pages/index.page.tsx
+++ b/apps/zoopi-web/pages/index.page.tsx
@@ -14,11 +14,11 @@ const HomePage = () => {
       >
         Home
       </div>
-      <Icon name="circle" />
+      <Icon name='circle' />
       <AnimalChip
         isSelected={false}
-        name="코코"
-        type="dog"
+        name='코코'
+        type='dog'
         bloodType={['DEA1-', 'DEA1.1']}
       />
     </div>

--- a/apps/zoopi-web/pages/test/modal.page.tsx
+++ b/apps/zoopi-web/pages/test/modal.page.tsx
@@ -21,7 +21,7 @@ const ModalTestPage = () => {
           onClose={() => {
             setIsConfirmShow(false);
           }}
-          title="링크발송"
+          title='링크발송'
           contents={
             '가입하신 이메일로 링크를 발송했습니다. \n 인증확인 후 비밀번호를 변경하세요!'
           }
@@ -33,7 +33,7 @@ const ModalTestPage = () => {
         />
       )}
       <button
-        type="button"
+        type='button'
         onClick={() => {
           setIsModalShow(true);
         }}
@@ -41,7 +41,7 @@ const ModalTestPage = () => {
         Modal Show
       </button>
       <button
-        type="button"
+        type='button'
         onClick={() => {
           setIsConfirmShow(true);
         }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "nx test",
     "tsc": "tsc --project apps/zoopi-web/tsconfig.json",
     "lint": "nx run zoopi-web:lint --fix",
-    "format": "prettier --write . && yarn run lint",
+    "prettier": "prettier --write .",
+    "format": "yarn run prettier && yarn run lint",
     "prepare": "husky install"
   },
   "private": true,


### PR DESCRIPTION
## Summary
Separate formatting on js files and non-js files

## Key Changes
- Use eslint for js files and prettier for non-js files
- add `yarn tsc` in pre-commit
- add `yarn test` in post-commit 

## Notes
- When we make a commit, typescript and lint check are done automatically
  - If if finds any error of it, commit fails with error
  - After this PR is merged, we will not need lint, tsc in PR checklist anymore! 
- After we make a commit, test run
  - commit is made anyway but we can see test result in termminal  


## Checklist
- [x] `yarn test`
